### PR TITLE
FIX: Stringify ci_run_id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ async function main() {
         branch: github.context.ref.replace(/^refs\/heads\//, ""),
         commit: github.context.sha,
         environment,
-        ciRunId: github.context.runId,
+        ciRunId: str(github.context.runId),
       }),
     });
 


### PR DESCRIPTION
Stringifying CI Run ID as it is causing 422 status codes in the pipeline start endpoint