### PR TITLE
FIX: Adjust stringify of CI run ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ async function main() {
         branch: github.context.ref.replace(/^refs\/heads\//, ""),
         commit: github.context.sha,
         environment,
-        ciRunId: str(github.context.runId),
+        ciRunId: github.context.runId.toString(),
       }),
     });
 


### PR DESCRIPTION
CI Run ID stringify was using python syntax instead of js