### PR TITLE
[ENG-5796] Allow Orchestra env to be passed in to action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra-action",
-  "version": "1.0.0",
+  "version": "1.1.4",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ async function main() {
       ? core.getInput("task_ids").split(",")
       : null;
 
-    core.info(`Starting pipeline '${pipelineId}'...`);
+    core.info(`[${orchestraEnv}] Starting pipeline '${pipelineId}'...`);
 
     const response = await fetch(START_PIPELINE_ENDPT(pipelineId), {
       method: "POST",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
 
+const orchestraEnv = process.env.ORCHESTRA_ENV || "app";
+
 const START_PIPELINE_ENDPT = (pipelineId) =>
-  `https://app.getorchestra.io/api/engine/public/pipelines/${pipelineId}/start`;
+  `https://${orchestraEnv}.getorchestra.io/api/engine/public/pipelines/${pipelineId}/start`;
 const PIPELINE_RUN_ENDPT = (pipelineRunId) =>
-  `https://app.getorchestra.io/api/engine/public/pipeline_runs/${pipelineRunId}/status`;
+  `https://${orchestraEnv}.getorchestra.io/api/engine/public/pipeline_runs/${pipelineRunId}/status`;
 const LINEAGE_APP_URL = (pipelineRunId) =>
-  `https://app.getorchestra.io/pipeline-runs/${pipelineRunId}/lineage`;
+  `https://${orchestraEnv}.getorchestra.io/pipeline-runs/${pipelineRunId}/lineage`;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
Allow the env var `ORCHESTRA_ENV` to be defined to switch between which instance of Orchestra to use. Built for internal testing - regular users of the action should not require any change or update. Leaving undocumented for that reason.

Tested with examples repository (working with no env var provided, and showing correctly specified env var):

![Screenshot 2025-05-13 at 11 16 08](https://github.com/user-attachments/assets/3f52141a-7a51-452f-9ad3-695494737c7b)
