### PR TITLE
FIX: ensure commit sha is not sent if branch input is provided

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra-action",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orchestra-action",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orchestra-action",
-      "version": "1.0.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra-action",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/index.js
+++ b/src/index.js
@@ -38,9 +38,7 @@ async function main() {
       ? core.getInput("task_ids").split(",")
       : null;
     const runInputs = parseJson(core.getInput("run_inputs"));
-    const branch =
-      core.getInput("branch") ||
-      github.context.ref.replace(/^refs\/heads\//, "");
+    const branchInput = core.getInput("branch");
 
     core.info(`Starting pipeline '${pipelineId}'...`);
 
@@ -51,8 +49,8 @@ async function main() {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        branch,
-        commit: github.context.sha,
+        branch: branchInput || github.context.ref.replace(/^refs\/heads\//, ""),
+        commit: branchInput ? null : github.context.sha,
         environment,
         ciRunId: github.context.runId.toString(),
         retryFromFailed,


### PR DESCRIPTION
This fixes a bug for when users set branch, to have pipeline YAML in one repo but DBT code in another

https://orchestra-dcj6077.slack.com/archives/C08JB5TU59P/p1768393386275149

